### PR TITLE
Improved the PKGBUILD according to our standard

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,24 +1,25 @@
 # Maintainer:  echo -n 'TWljaGFsIFMuIDxtaWNoYWxAZ2V0Y3J5c3QuYWw+' | base64 -d
+# Contributor: echo -n 'cmNhbmRhdUBnZXRjcnlzdC5hbA=='             | base64 -d
 # Contributor: echo -n 'amFzaW8gPGphc2lvQGdldGNyeXN0LmFsPg=='     | base64 -d
 
-_name=wallpapers
-
-pkgname="crystal-$_name"
+pkgname=crystal-wallpapers
+_pkgname=wallpapers
 pkgver=1.0.3
-pkgrel=2
+pkgrel=3
 pkgdesc='Crystal Linux Wallpapers'
 arch=('any')
-url="https://github.com/crystal-linux/$_name"
+url="https://github.com/crystal-linux/${_pkgname}"
 license=('GPL')
-source=("git+$url")
-makedepends=('git')
-sha256sums=('SKIP')
+source=("${pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('3d2fed68b505606ba2f7f5d6361692d8dd1e2017bf1dbcee939f1e77d9ef771e')
 
 package() {
-    cd "$srcdir/$_name"
-
-    find . \
-        -type f \
-     \( -name "*.png" -o -name "*.svg" \) \
-        -exec install -Dm 0755 -t "$pkgdir/usr/share/backgrounds/crystal/." {} +
+    cd "${srcdir}/${_pkgname}-${pkgver}"
+    install -Dm 644 "crystal-blob light.png" "${pkgdir}/usr/share/backgrounds/crystal/crystal-blob light.png"
+    install -Dm 644 crystal-waves-horizontal.png "${pkgdir}/usr/share/backgrounds/crystal/crystal-waves-horizontal.png"
+    install -Dm 644 crystal-waves-vertical.png "${pkgdir}/usr/share/backgrounds/crystal/crystal-waves-vertical.png"
+    install -Dm 644 gaypaper.png "${pkgdir}/usr/share/backgrounds/crystal/gaypaper.png"
+    install -Dm 644 "crystal-blob light.svg" "${pkgdir}/usr/share/backgrounds/crystal/crystal-blob light.svg"
+    install -Dm 644 crystal-blob.svg "${pkgdir}/usr/share/backgrounds/crystal/crystal-blob.svg"
+    install -Dm 644 gaypaper.svg "${pkgdir}/usr/share/backgrounds/crystal/gaypaper.svg"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,11 +15,7 @@ sha256sums=('3d2fed68b505606ba2f7f5d6361692d8dd1e2017bf1dbcee939f1e77d9ef771e')
 
 package() {
     cd "${srcdir}/${_pkgname}-${pkgver}"
-    install -Dm 644 "crystal-blob light.png" "${pkgdir}/usr/share/backgrounds/crystal/crystal-blob light.png"
-    install -Dm 644 crystal-waves-horizontal.png "${pkgdir}/usr/share/backgrounds/crystal/crystal-waves-horizontal.png"
-    install -Dm 644 crystal-waves-vertical.png "${pkgdir}/usr/share/backgrounds/crystal/crystal-waves-vertical.png"
-    install -Dm 644 gaypaper.png "${pkgdir}/usr/share/backgrounds/crystal/gaypaper.png"
-    install -Dm 644 "crystal-blob light.svg" "${pkgdir}/usr/share/backgrounds/crystal/crystal-blob light.svg"
-    install -Dm 644 crystal-blob.svg "${pkgdir}/usr/share/backgrounds/crystal/crystal-blob.svg"
-    install -Dm 644 gaypaper.svg "${pkgdir}/usr/share/backgrounds/crystal/gaypaper.svg"
+    install -d "${pkgdir}/usr/share/backgrounds/crystal/"
+    install -Dm 644 *.png "${pkgdir}/usr/share/backgrounds/crystal/"
+    install -Dm 644 *.svg "${pkgdir}/usr/share/backgrounds/crystal/"
 }


### PR DESCRIPTION
Hi,

A round of improvements for the `wallpapers` PKGBUILD:

- Switched all vars to `${var}` format.
- Changed the `_name` var to `_pkgname` which is more standard (that's just a style change tho).
- Replaced source from `git` to release's archive. Added the integrity check accordingly and removed the `git` makedepend.
- Replaced the `find ... -exec install ...` command by a `install` command directly.
- Changed the permissions of the installed file from `755` to `644`.
- *Explicitly listed every files being installed on the end user's machine via the `install` commands in the `package ()` function.*

**About the last point**:
In my opinion, the clearer/most transparent the PKGBUILD is about what it installs on the end user's machine, the better. This is why I usually avoid using wildcards (`*`) in PKGBUILD when possible, in favor of listing the installed files explicitly. I tend to find that more "elegant".

On the other hand, I'm aware that this is debatable. Firstly because this is my opinion (and not necessarily everyone's opinion); but also because in this particular package's case, the remote directory which contains the installed files is created during the build (I mean, it is not an already existing directory that already contains files), so it's pretty easy to find out which files has been installed. 
Also, I'm aware that this method can be a bit more "painful" to maintain as each adding/removing will involve a modification to the `package ()` function (but does the wallpapers repo as a lot of adding/removing tho?).

Anyway, if you prefer to use wildcards to avoid a potentially frequent maintenance, we could use to this:
```
package() {
    cd "${srcdir}/${_pkgname}-${pkgver}"
    install -d "${pkgdir}/usr/share/backgrounds/crystal/"
    install -Dm 644 *.png "${pkgdir}/usr/share/backgrounds/crystal/"
    install -Dm 644 *.svg "${pkgdir}/usr/share/backgrounds/crystal/"
}
```

Let me know your thoughts and I'll change the `package ()` function if needed!
